### PR TITLE
feat(3): Project detail panel with stage timeline and error log

### DIFF
--- a/backend/src/stateReader.ts
+++ b/backend/src/stateReader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { ProjectSummary, PipelineState, DeployRegistry } from './types';
+import { ProjectSummary, ProjectDetail, PipelineState, DeployRegistry } from './types';
 
 const WORKSPACE = process.env.KARAKURI_WORKSPACE ?? '';
 
@@ -87,7 +87,7 @@ export function readAllProjects(): ProjectSummary[] {
   return projects;
 }
 
-export function readProject(name: string): ProjectSummary | null {
+export function readProject(name: string): ProjectDetail | null {
   const stateFile = path.join(getStateDir(), name, 'pipeline-state.json');
   if (!fs.existsSync(stateFile)) return null;
 
@@ -95,7 +95,13 @@ export function readProject(name: string): ProjectSummary | null {
   if (!state) return null;
 
   const registry = readJsonSafe<DeployRegistry>(getRegistryPath()) ?? {};
-  return normalizeProject(name, state, registry);
+  const summary = normalizeProject(name, state, registry);
+
+  return {
+    ...summary,
+    errors: Array.isArray(state.errors) ? state.errors : [],
+    design: state.design,
+  };
 }
 
 export function getStateGlob(): string {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,3 +1,16 @@
+export interface ProjectError {
+  phase: string;
+  error: string;
+  recovery?: string;
+  at: string;
+}
+
+export interface ProjectDesign {
+  status: string;
+  reason?: string;
+  created_at?: string;
+}
+
 export interface ProjectSummary {
   name: string;
   status: string;
@@ -11,6 +24,12 @@ export interface ProjectSummary {
   currentFeature?: { number: number; phase: string };
 }
 
+// Extended version returned by GET /api/projects/:name
+export interface ProjectDetail extends ProjectSummary {
+  errors: ProjectError[];
+  design?: ProjectDesign;
+}
+
 export interface PipelineState {
   version: number;
   status: string;
@@ -22,6 +41,12 @@ export interface PipelineState {
   created_at: string;
   errors: Array<{ phase: string; error: string; at: string; recovery?: string }>;
   features?: Record<string, { status: string; phase?: string; completed_at?: string }>;
+  completed_features?: number[];
+  design?: {
+    status: string;
+    reason?: string;
+    created_at?: string;
+  };
 }
 
 export interface DeployRegistry {

--- a/frontend/src/components/ProjectDetail.tsx
+++ b/frontend/src/components/ProjectDetail.tsx
@@ -1,6 +1,19 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ProjectSummary, ProjectDetail as ProjectDetailType } from '../types';
+import { formatProjectName, timeAgo, statusToColumn } from '../utils';
 
-import { ProjectSummary } from '../types';
-import { formatProjectName, timeAgo } from '../utils';
+// The 9 pipeline stages in order
+const STAGES = [
+  { key: 'init',         label: 'Init' },
+  { key: 'review',       label: 'Review' },
+  { key: 'pm',           label: 'PM' },
+  { key: 'architecture', label: 'Architecture' },
+  { key: 'ux',           label: 'UX / Design' },
+  { key: 'features',     label: 'Features' },
+  { key: 'deploy',       label: 'Deploy' },
+  { key: 'e2e',          label: 'E2E' },
+  { key: 'complete',     label: 'Complete' },
+] as const;
 
 interface Props {
   project: ProjectSummary;
@@ -8,65 +21,156 @@ interface Props {
 }
 
 export function ProjectDetail({ project, onClose }: Props) {
-  const issueUrl = project.issueNumber > 0
-    ? `https://github.com/${project.repo}/issues/${project.issueNumber}`
-    : null;
+  const [detail, setDetail] = useState<ProjectDetailType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch full project detail
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetch(`/api/projects/${encodeURIComponent(project.name)}`)
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then((data: ProjectDetailType) => {
+        setDetail(data);
+        setLoading(false);
+      })
+      .catch((e: Error) => {
+        setError(e.message);
+        setLoading(false);
+      });
+  }, [project.name]);
+
+  // Close on Escape
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const d = detail ?? project as unknown as ProjectDetailType;
+  const currentColumn = statusToColumn(d.status);
+  const currentStageIdx = STAGES.findIndex(s => s.key === currentColumn);
+  const issueUrl = d.issueNumber > 0 ? `https://github.com/${d.repo}/issues/${d.issueNumber}` : null;
+  const repoUrl = `https://github.com/${d.repo}`;
 
   return (
     <div className="detail-overlay" onClick={onClose}>
       <div className="detail-panel" onClick={e => e.stopPropagation()}>
+
+        {/* ── Header ─────────────────────────────────────────────── */}
         <div className="detail-header">
-          <h2>{formatProjectName(project.name)}</h2>
-          <button className="detail-close" onClick={onClose}>✕</button>
+          <div className="detail-header-left">
+            <h2 className="detail-title">{formatProjectName(d.name)}</h2>
+            <div className="detail-header-links">
+              <a href={repoUrl} target="_blank" rel="noreferrer" className="detail-link-chip">
+                📦 {d.repo}
+              </a>
+              {issueUrl && (
+                <a href={issueUrl} target="_blank" rel="noreferrer" className="detail-link-chip">
+                  🔗 #{d.issueNumber}
+                </a>
+              )}
+              {d.deployUrl && (
+                <a href={d.deployUrl} target="_blank" rel="noreferrer" className="detail-link-chip detail-deploy">
+                  🌐 Live
+                </a>
+              )}
+            </div>
+          </div>
+          <button className="detail-close" onClick={onClose} aria-label="Close">✕</button>
         </div>
 
         <div className="detail-body">
-          <div className="detail-row">
-            <span className="detail-label">Status</span>
-            <span className="detail-value status-chip">{project.status}</span>
-          </div>
-          <div className="detail-row">
-            <span className="detail-label">Repo</span>
-            <a href={`https://github.com/${project.repo}`} target="_blank" rel="noreferrer"
-              className="detail-link">{project.repo}</a>
-          </div>
-          {issueUrl && (
-            <div className="detail-row">
-              <span className="detail-label">Issue</span>
-              <a href={issueUrl} target="_blank" rel="noreferrer"
-                className="detail-link">#{project.issueNumber}</a>
-            </div>
-          )}
-          {project.deployUrl && (
-            <div className="detail-row">
-              <span className="detail-label">Deploy</span>
-              <a href={project.deployUrl} target="_blank" rel="noreferrer"
-                className="detail-link">{project.deployUrl}</a>
-            </div>
-          )}
-          <div className="detail-row">
-            <span className="detail-label">Updated</span>
-            <span className="detail-value">{timeAgo(project.updatedAt)}</span>
-          </div>
-          <div className="detail-row">
-            <span className="detail-label">Errors</span>
-            <span className="detail-value" style={{ color: project.errorCount > 0 ? 'var(--red)' : 'var(--text-muted)' }}>
-              {project.errorCount}
-            </span>
+          {/* Status + timestamps */}
+          <div className="detail-meta-row">
+            <span className="status-chip">{d.status}</span>
+            <span className="detail-time">Updated {timeAgo(d.updatedAt)}</span>
           </div>
 
-          {project.completedFeatures.length > 0 && (
-            <div className="detail-row">
-              <span className="detail-label">Completed</span>
-              <span className="detail-value">Features {project.completedFeatures.join(', ')}</span>
+          {/* ── Stage Timeline ──────────────────────────────────── */}
+          <section className="detail-section">
+            <h3 className="detail-section-title">Stage Timeline</h3>
+            <div className="stage-list">
+              {STAGES.map((stage, idx) => {
+                const isComplete  = idx < currentStageIdx;
+                const isCurrent   = idx === currentStageIdx;
+                const isUpcoming  = idx > currentStageIdx;
+
+                return (
+                  <div key={stage.key}
+                    className={`stage-row ${isComplete ? 'stage-done' : ''} ${isCurrent ? 'stage-active' : ''} ${isUpcoming ? 'stage-pending' : ''}`}>
+                    <span className="stage-icon">
+                      {isComplete  ? '✅' : isCurrent ? '🔄' : '⬜'}
+                    </span>
+                    <span className="stage-label">{stage.label}</span>
+                    {isCurrent && (
+                      <span className="stage-current-badge">current</span>
+                    )}
+                  </div>
+                );
+              })}
             </div>
+          </section>
+
+          {/* ── Error Log ──────────────────────────────────────── */}
+          {loading && <div className="detail-loading">Loading…</div>}
+          {error && <div className="detail-error">Failed to load detail: {error}</div>}
+
+          {!loading && detail && detail.errors.length > 0 && (
+            <section className="detail-section">
+              <h3 className="detail-section-title" style={{ color: 'var(--red)' }}>
+                Errors ({detail.errors.length})
+              </h3>
+              <div className="error-list">
+                {detail.errors.map((err, i) => (
+                  <div key={i} className="error-card">
+                    <div className="error-phase">{err.phase}</div>
+                    <div className="error-message">{err.error}</div>
+                    {err.recovery && (
+                      <div className="error-recovery">{err.recovery}</div>
+                    )}
+                    <div className="error-timestamp">{timeAgo(err.at)}</div>
+                  </div>
+                ))}
+              </div>
+            </section>
           )}
 
-          {project.currentFeature && (
-            <div className="detail-row">
-              <span className="detail-label">In Progress</span>
-              <span className="detail-value">Feature {project.currentFeature.number} · {project.currentFeature.phase}</span>
-            </div>
+          {/* ── Design Section ──────────────────────────────────── */}
+          {!loading && detail?.design && detail.design.status !== 'skipped' && (
+            <section className="detail-section">
+              <h3 className="detail-section-title">Design</h3>
+              <div className="design-block">
+                <span className="design-status">{detail.design.status}</span>
+                {detail.design.reason && (
+                  <p className="design-reason">{detail.design.reason}</p>
+                )}
+              </div>
+            </section>
+          )}
+
+          {/* ── Features ────────────────────────────────────────── */}
+          {(d.completedFeatures.length > 0 || d.currentFeature) && (
+            <section className="detail-section">
+              <h3 className="detail-section-title">Features</h3>
+              {d.completedFeatures.map(n => (
+                <div key={n} className="stage-row stage-done">
+                  <span className="stage-icon">✅</span>
+                  <span className="stage-label">Feature {n}</span>
+                </div>
+              ))}
+              {d.currentFeature && (
+                <div className="stage-row stage-active">
+                  <span className="stage-icon">🔄</span>
+                  <span className="stage-label">Feature {d.currentFeature.number}</span>
+                  <span className="stage-current-badge">{d.currentFeature.phase}</span>
+                </div>
+              )}
+            </section>
           )}
         </div>
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -353,3 +353,198 @@ a:hover { text-decoration: underline; }
   font-size: 0.78rem;
   font-family: monospace;
 }
+
+/* ── ProjectDetail (enhanced) ───────────────────────────────────────────── */
+
+.detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  z-index: 1;
+}
+
+.detail-header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.detail-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail-header-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.detail-link-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: border-color var(--transition), color var(--transition);
+}
+.detail-link-chip:hover { border-color: var(--blue); color: var(--text); text-decoration: none; }
+.detail-link-chip.detail-deploy { color: var(--green); border-color: rgba(63,185,80,0.3); }
+.detail-link-chip.detail-deploy:hover { border-color: var(--green); }
+
+.detail-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+.detail-time {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.detail-loading,
+.detail-error {
+  font-size: 0.82rem;
+  padding: 8px;
+  color: var(--text-muted);
+}
+.detail-error { color: var(--red); }
+
+/* ── Sections ────────────────────────────────────────────────────────────── */
+
+.detail-section {
+  padding-top: 4px;
+}
+
+.detail-section-title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+/* ── Stage Timeline ─────────────────────────────────────────────────────── */
+
+.stage-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stage-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 0.82rem;
+}
+
+.stage-done  { background: rgba(63, 185, 80, 0.06); }
+.stage-active { background: rgba(56, 139, 253, 0.1); border: 1px solid rgba(56,139,253,0.25); }
+.stage-pending { opacity: 0.45; }
+
+.stage-icon { font-size: 0.9rem; flex-shrink: 0; }
+
+.stage-label { flex: 1; color: var(--text); }
+
+.stage-current-badge {
+  font-size: 0.7rem;
+  padding: 1px 7px;
+  background: rgba(56,139,253,0.2);
+  color: var(--blue);
+  border-radius: 10px;
+  border: 1px solid rgba(56,139,253,0.35);
+}
+
+/* ── Error Log ──────────────────────────────────────────────────────────── */
+
+.error-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.error-card {
+  background: rgba(248, 81, 73, 0.06);
+  border: 1px solid rgba(248, 81, 73, 0.2);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.error-phase {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--red);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.error-message {
+  font-size: 0.8rem;
+  font-family: ui-monospace, 'Cascadia Code', monospace;
+  color: var(--text);
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.error-recovery {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-style: italic;
+  word-break: break-word;
+}
+
+.error-timestamp {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+/* ── Design Block ───────────────────────────────────────────────────────── */
+
+.design-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.design-status {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--amber);
+  width: fit-content;
+}
+
+.design-reason {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,6 +11,24 @@ export interface ProjectSummary {
   currentFeature?: { number: number; phase: string };
 }
 
+export interface ProjectError {
+  phase: string;
+  error: string;
+  recovery?: string;
+  at: string;
+}
+
+export interface ProjectDesign {
+  status: string;
+  reason?: string;
+  created_at?: string;
+}
+
+export interface ProjectDetail extends ProjectSummary {
+  errors: ProjectError[];
+  design?: ProjectDesign;
+}
+
 export interface WsMessage {
   type: 'snapshot' | 'project_updated' | 'log_lines';
   projects?: ProjectSummary[];


### PR DESCRIPTION
Feature #3 for Issue #1

## Changes (5 files, 398 insertions / 50 deletions)

### Backend

**`backend/src/types.ts`**
- `ProjectError` — `{phase, error, recovery?, at}`
- `ProjectDesign` — `{status, reason?, created_at?}`
- `ProjectDetail extends ProjectSummary` — adds `errors[]` + `design?`
- `PipelineState` — added `design?` and `completed_features?` fields

**`backend/src/stateReader.ts`**
- `readProject()` now returns `ProjectDetail` with full `errors[]` + `design` from state file

### Frontend

**`frontend/src/types.ts`** — mirrored `ProjectError`, `ProjectDesign`, `ProjectDetail`

**`frontend/src/components/ProjectDetail.tsx`** (full rewrite)
- Fetches `GET /api/projects/:name` on mount for raw errors + design
- Escape key closes panel
- **Header**: project name, repo chip, issue chip, deploy chip
- **Stage Timeline** (9 stages): ✅ completed / 🔄 current (+ blue badge) / ⬜ upcoming
- **Error Log** (shown only if `errorCount > 0`): phase (red bold), message (monospace), recovery (italic gray), timestamp
- **Design** (shown if `design && status !== 'skipped'`): amber status chip, italic reason
- **Features**: completed + in-progress rows with icons

**`frontend/src/index.css`** — all new styles for stage timeline, error cards, design block, detail header

## Acceptance Criteria
- [x] Clicking card opens detail panel with project name ✅
- [x] Stage timeline shows current stage with spinner 🔄 ✅
- [x] Completed stages show ✅ checkmarks ✅
- [x] Errors listed if `errorCount > 0` ✅
- [x] Panel closes on X or Escape ✅

## Build
- Backend TypeScript: 0 errors ✅
- Frontend TypeScript + Vite: 0 errors, **153 KB / 49 KB gzip** ✅

---
*Created by Karakuri Dev Agent*