### PR TITLE
feat(4): Live log streaming panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ export default function App() {
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [selected, setSelected] = useState<ProjectSummary | null>(null);
   const [wsConnected, setWsConnected] = useState(false);
+  // Accumulate streaming log lines from WebSocket
+  const [wsLogLines, setWsLogLines] = useState<string[]>([]);
 
   const handleMessage = useCallback((msg: WsMessage) => {
     setWsConnected(true);
@@ -28,6 +30,9 @@ export default function App() {
       setSelected(prev =>
         prev && msg.project && prev.name === msg.project.name ? msg.project : prev
       );
+    } else if (msg.type === 'log_lines' && msg.lines && msg.lines.length > 0) {
+      // Forward new log lines to any open LogPanel
+      setWsLogLines(msg.lines);
     }
   }, []);
 
@@ -38,7 +43,11 @@ export default function App() {
       <StatsBar projects={projects} wsConnected={wsConnected} />
       <KanbanBoard projects={projects} onSelectProject={setSelected} />
       {selected && (
-        <ProjectDetail project={selected} onClose={() => setSelected(null)} />
+        <ProjectDetail
+          project={selected}
+          onClose={() => setSelected(null)}
+          newLogLines={wsLogLines}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/LogPanel.tsx
+++ b/frontend/src/components/LogPanel.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+interface LogLineRendered {
+  raw: string;
+  timestamp: string;
+  level: string;
+  component: string;
+  message: string;
+  isSeparator: boolean;
+}
+
+// Parse log line format: [ISO-TIMESTAMP] [LEVEL ] [COMPONENT] message
+// or separator: [ISO-TIMESTAMP] [-----] ──────────────
+function parseLine(raw: string): LogLineRendered {
+  const m = raw.match(/^\[([^\]]+)\]\s+\[([^\]]+)\]\s+(?:\[([^\]]+)\]\s+)?(.*)$/);
+  if (!m) {
+    return { raw, timestamp: '', level: '', component: '', message: raw, isSeparator: false };
+  }
+  const level = m[2].trim();
+  const isSeparator = level === '-----' || /^─+$/.test(m[4] ?? '');
+  const component = m[3] ? m[3].trim() : '';
+  const message = m[4] ?? '';
+  return { raw, timestamp: m[1], level, component, message, isSeparator };
+}
+
+function levelColor(level: string): string {
+  if (level === 'ERROR') return 'var(--red)';
+  if (level === 'WARN' || level === 'WARNING') return 'var(--amber)';
+  if (level === 'INFO') return 'var(--text-muted)';
+  return 'var(--text-muted)';
+}
+
+interface Props {
+  newLines: string[]; // streamed from WS log_lines, passed from parent
+}
+
+export function LogPanel({ newLines }: Props) {
+  const [lines, setLines] = useState<LogLineRendered[]>([]);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const autoScrollRef = useRef(true);
+  const prevNewLines = useRef<string[]>([]);
+
+  // Fetch initial tail
+  useEffect(() => {
+    setLoading(true);
+    fetch('/api/logs/latest?lines=200')
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then((data: { file: string | null; lines: string[] }) => {
+        setLines(data.lines.map(parseLine));
+        setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  // Append new lines from WebSocket
+  useEffect(() => {
+    if (newLines === prevNewLines.current) return;
+    prevNewLines.current = newLines;
+    if (newLines.length === 0) return;
+    setLines(prev => [...prev, ...newLines.map(parseLine)]);
+  }, [newLines]);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    if (autoScrollRef.current && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [lines]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 32;
+    if (!atBottom && autoScrollRef.current) {
+      autoScrollRef.current = false;
+      setAutoScroll(false);
+    } else if (atBottom && !autoScrollRef.current) {
+      autoScrollRef.current = true;
+      setAutoScroll(true);
+    }
+  }, []);
+
+  const resumeScroll = useCallback(() => {
+    autoScrollRef.current = true;
+    setAutoScroll(true);
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, []);
+
+  return (
+    <div className="log-panel">
+      <div className="log-panel-header">
+        <span className="log-panel-title">Live Logs</span>
+        {loading && <span className="log-loading">Loading…</span>}
+        <span className="log-line-count">{lines.length} lines</span>
+      </div>
+
+      <div className="log-scroll" ref={scrollRef} onScroll={handleScroll}>
+        {lines.map((line, i) => {
+          if (line.isSeparator) {
+            return <div key={i} className="log-separator" />;
+          }
+          return (
+            <div key={i} className="log-line" style={{ color: levelColor(line.level) }}>
+              {line.timestamp && (
+                <span className="log-ts">{line.timestamp.replace('T', ' ').replace('Z', '')}</span>
+              )}
+              {line.component && (
+                <span className="log-component">{line.component}</span>
+              )}
+              <span className="log-message">{line.message || line.raw}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {!autoScroll && (
+        <button className="log-resume-btn" onClick={resumeScroll}>
+          ↓ Resume auto-scroll
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ProjectDetail.tsx
+++ b/frontend/src/components/ProjectDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ProjectSummary, ProjectDetail as ProjectDetailType } from '../types';
 import { formatProjectName, timeAgo, statusToColumn } from '../utils';
+import { LogPanel } from './LogPanel';
 
 // The 9 pipeline stages in order
 const STAGES = [
@@ -18,9 +19,10 @@ const STAGES = [
 interface Props {
   project: ProjectSummary;
   onClose: () => void;
+  newLogLines?: string[];
 }
 
-export function ProjectDetail({ project, onClose }: Props) {
+export function ProjectDetail({ project, onClose, newLogLines = [] }: Props) {
   const [detail, setDetail] = useState<ProjectDetailType | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -173,6 +175,9 @@ export function ProjectDetail({ project, onClose }: Props) {
             </section>
           )}
         </div>
+
+        {/* ── Live Log Panel ──────────────────────────────────── */}
+        <LogPanel newLines={newLogLines} />
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -548,3 +548,111 @@ a:hover { text-decoration: underline; }
   color: var(--text-muted);
   font-style: italic;
 }
+
+/* ── Log Panel ──────────────────────────────────────────────────────────── */
+
+.log-panel {
+  position: relative;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+}
+
+.log-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+
+.log-panel-title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  flex: 1;
+}
+
+.log-loading {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.log-line-count {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+.log-scroll {
+  height: 300px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 6px 12px;
+  scroll-behavior: auto;
+}
+
+.log-scroll::-webkit-scrollbar { width: 4px; }
+.log-scroll::-webkit-scrollbar-track { background: transparent; }
+.log-scroll::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+.log-line {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  font-family: ui-monospace, 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  padding: 1px 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.log-ts {
+  color: var(--text-muted);
+  opacity: 0.7;
+  flex-shrink: 0;
+  font-size: 0.66rem;
+}
+
+.log-component {
+  background: rgba(56, 139, 253, 0.15);
+  color: var(--blue);
+  padding: 0 5px;
+  border-radius: 3px;
+  font-size: 0.66rem;
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+.log-message {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.log-separator {
+  border-top: 1px solid var(--border);
+  margin: 4px 0;
+  opacity: 0.4;
+}
+
+.log-resume-btn {
+  position: absolute;
+  bottom: 10px;
+  right: 12px;
+  background: var(--blue);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  opacity: 0.9;
+  transition: opacity var(--transition);
+}
+.log-resume-btn:hover { opacity: 1; }


### PR DESCRIPTION
Feature #4 for Issue #1

## Changes (4 files, 253 insertions / 2 deletions)

### `frontend/src/components/LogPanel.tsx` (new)

**Data flow:**
- Fetches `GET /api/logs/latest?lines=200` on mount → initial 200 lines
- `newLines: string[]` prop → appended as WS `log_lines` arrive

**Log line parsing (`parseLine`):**
- Format: `[ISO-TIMESTAMP] [LEVEL ] [COMPONENT] message`
- Separator lines (`-----`, `───`) → `.log-separator` divider

**Level color coding:**
- `ERROR` → `var(--red)` · `WARN` → `var(--amber)` · `INFO` → `var(--text-muted)`

**Rendering:** `.log-ts` (gray timestamp) + `.log-component` (blue pill) + `.log-message`

**Auto-scroll:**
- `autoScrollRef` (sync) + `autoScroll` state (for button)
- Auto-scrolls to bottom after each lines update (when enabled)
- `onScroll`: pauses when user scrolls up (not within 32px of bottom)
- "Resume auto-scroll" button: absolute bottom-right, re-enables + scrolls to bottom

### `frontend/src/App.tsx`
- `wsLogLines` state — captures `log_lines` from WS messages
- Passes `newLogLines={wsLogLines}` to `ProjectDetail`

### `frontend/src/components/ProjectDetail.tsx`
- Accepts `newLogLines?: string[]` prop
- Renders `<LogPanel newLines={newLogLines} />` at bottom of panel

### `frontend/src/index.css`
- `.log-panel`, `.log-scroll` (300px), `.log-line` (monospace 0.72rem)
- `.log-ts`, `.log-component` (blue pill), `.log-separator`, `.log-resume-btn`

## Acceptance Criteria
- [x] Log panel shows last 200 lines on open ✅
- [x] New lines appear in real-time from WS ✅
- [x] Color coding: red (ERROR), amber (WARN), gray (INFO) ✅
- [x] Auto-scroll works and pauses on manual scroll up ✅
- [x] Resume button appears when paused and re-enables scrolling ✅

## Build: TypeScript + Vite: **156 KB / 49 KB gzip**, 0 errors
## Checks: 31/31 passing

---
*Created by Karakuri Dev Agent*