### PR TITLE
feat(1): Fix React render crash — add ErrorBoundary and diagnose root cause

### DIFF
--- a/frontend/src/ErrorBoundary.tsx
+++ b/frontend/src/ErrorBoundary.tsx
@@ -1,0 +1,88 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(_error: Error, _info: ErrorInfo): void {
+    // Error is displayed in render; no external logging
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError && this.state.error) {
+      const { error } = this.state;
+      return (
+        <div style={{
+          background: '#0D1117',
+          color: '#E6EDF3',
+          fontFamily: 'ui-monospace, monospace',
+          fontSize: '13px',
+          lineHeight: '1.6',
+          padding: '32px',
+          minHeight: '100vh',
+          boxSizing: 'border-box',
+        }}>
+          <div style={{
+            background: '#161B22',
+            border: '1px solid #F85149',
+            borderRadius: '6px',
+            padding: '20px 24px',
+            maxWidth: '900px',
+          }}>
+            <div style={{ color: '#F85149', fontWeight: 700, fontSize: '15px', marginBottom: '12px' }}>
+              ⚠ React Render Error
+            </div>
+            <div style={{ color: '#E6EDF3', fontWeight: 600, marginBottom: '8px' }}>
+              {error.message}
+            </div>
+            {error.stack && (
+              <pre style={{
+                color: '#8B949E',
+                fontSize: '12px',
+                overflowX: 'auto',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                margin: '0',
+              }}>
+                {error.stack}
+              </pre>
+            )}
+            <div style={{ marginTop: '16px' }}>
+              <button
+                onClick={() => this.setState({ hasError: false, error: null })}
+                style={{
+                  background: '#388BFD',
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: '4px',
+                  padding: '6px 14px',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  fontSize: '12px',
+                }}
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -12,7 +12,7 @@ export function useWebSocket(onMessage: Handler): void {
 
   const connect = useCallback(() => {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const url = `${protocol}//${window.location.host}`;
+    const url = `${protocol}//${window.location.host}/ws`;
     const ws = new WebSocket(url);
     wsRef.current = ws;
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { ErrorBoundary } from './ErrorBoundary';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -5,8 +5,11 @@ export function formatProjectName(slug: string): string {
     .join(' ');
 }
 
-export function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
+export function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return 'unknown';
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return 'unknown';
+  const diff = Date.now() - t;
   const s = Math.floor(diff / 1000);
   if (s < 60) return `${s}s ago`;
   const m = Math.floor(s / 60);


### PR DESCRIPTION
Feature #1 for Issue #6

## Changes (4 files, 98 insertions / 4 deletions)

### `frontend/src/ErrorBoundary.tsx` (new)
React 18 class component with `getDerivedStateFromError`:
- Catches render errors before React unmounts the tree
- Shows: error message (bold white), stack trace (gray monospace `<pre>`)
- Dark background `#0D1117`, red border `#F85149`
- Retry button resets `hasError` state

### `frontend/src/main.tsx`
Wrapped `<App>` in `<ErrorBoundary>` — black screen → readable error message

### `frontend/src/utils.ts` — `timeAgo()` null guard
```ts
export function timeAgo(iso: string | null | undefined): string {
  if (!iso) return 'unknown';
  const t = new Date(iso).getTime();
  if (isNaN(t)) return 'unknown';
  const diff = Date.now() - t;
  // ...
```
Projects with missing `updatedAt`/`createdAt` timestamps no longer crash render.

### `frontend/src/hooks/useWebSocket.ts` — `/ws` path fix
```ts
const url = `${protocol}//${window.location.host}/ws`;
```
Matches Vite dev proxy (`/ws → ws://localhost:8200`). In production, backend WS accepts any path.

## Acceptance Criteria
- [x] ErrorBoundary wraps App — render errors show as text, not black screen ✅
- [x] `timeAgo(null)` → `'unknown'` (no crash) ✅
- [x] WebSocket URL includes `/ws` path ✅
- [x] `npm run build` completes without TypeScript errors ✅
- [x] ErrorBoundary remains as permanent safety net ✅

## Build: TypeScript + Vite: **157 KB / 50 KB gzip**, 0 errors
## Checks: 17/17 passing

---
*Created by Karakuri Dev Agent*