### PR TITLE
feat(2): Fix stateReader to read completed_features field from state files

### DIFF
--- a/backend/src/stateReader.ts
+++ b/backend/src/stateReader.ts
@@ -28,11 +28,17 @@ function readJsonSafe<T>(filePath: string): T | null {
 function normalizeProject(name: string, state: PipelineState, registry: DeployRegistry): ProjectSummary {
   const deploy = registry[name];
 
-  // Compute completed features from state.features map
+  // Compute completed features — prefer modern completed_features[] field,
+  // fall back to legacy state.features object map
   const completedFeatures: number[] = [];
   let currentFeature: { number: number; phase: string } | undefined;
 
-  if (state.features) {
+  if (state.completed_features && Array.isArray(state.completed_features)) {
+    // Modern state files: completed_features is a number[] e.g. [1, 2, 3, 4]
+    completedFeatures.push(...state.completed_features);
+    completedFeatures.sort((a, b) => a - b);
+  } else if (state.features) {
+    // Legacy state files: features is Record<string, {status, phase?, ...}>
     for (const [key, feat] of Object.entries(state.features)) {
       const num = parseInt(key.replace(/\D/g, ''), 10);
       if (isNaN(num)) continue;


### PR DESCRIPTION
Feature #2 for Issue #6

## Changes (1 file, 8 insertions / 2 deletions)

### `backend/src/stateReader.ts` — `normalizeProject()`

**Problem:** `normalizeProject()` only read `state.features` (legacy `Record<string, {status,...}>`). Modern state files use `completed_features: number[]` (e.g., `[1, 2, 3, 4]`). Projects with `completed_features` showed `completedFeatures: []` in the API.

**Fix:** Check `state.completed_features` first:

```ts
if (state.completed_features && Array.isArray(state.completed_features)) {
  completedFeatures.push(...state.completed_features);
  completedFeatures.sort((a, b) => a - b);
} else if (state.features) {
  // Legacy Object.entries loop (unchanged)
}
```

`completed_features?: number[]` was already in `PipelineState` (no types.ts change needed).

## Smoke Test
- `karakuri-dashboard`: `completedFeatures=[1]` ✅
- `zero-based-budget`: `completedFeatures=[1,2,3,4]` ✅

## Acceptance Criteria
- [x] `GET /api/projects` returns correct `completedFeatures` for modern state files ✅
- [x] Features column shows ✅ checkmarks for completed features ✅
- [x] No TypeScript errors in backend compilation ✅

---
*Created by Karakuri Dev Agent*